### PR TITLE
Feature/i18n remaining translation items

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9656,7 +9656,7 @@ export function createApp() {
   );
 
   app.get('/api/integrations/bring/catalog', requireAuth, async (_req, res) => {
-    const catalog = await loadBringCatalog();
+    const catalog = await loadBringCatalog(APP_LOCALE);
     res.set('Cache-Control', 'private, max-age=21600');
     res.json({ success: true, catalog });
   });

--- a/server/app.js
+++ b/server/app.js
@@ -9920,9 +9920,23 @@ export function createApp() {
         }
       }
     }));
+    const localizeIndexHtml = html => html
+      .replace('<html lang="de">', `<html lang="${APP_LANGUAGE}">`)
+      .replace(
+        /<title>.*?<\/title>/,
+        `<title>${translate('labels.htmlTitle')}</title>`
+      )
+      .replace(
+        /(<meta name="description" content=").*?(" \/>)/,
+        `$1${translate('labels.htmlDescription')}$2`
+      );
     app.get(/^(?!\/api\/).*/, (_req, res) => {
       res.setHeader('Cache-Control', 'no-cache');
-      res.sendFile(path.join(distPath, 'index.html'));
+      res.type('html').send(
+        localizeIndexHtml(
+          fs.readFileSync(path.join(distPath, 'index.html'), 'utf8')
+        )
+      );
     });
   }
 

--- a/server/bringCatalog.js
+++ b/server/bringCatalog.js
@@ -2,24 +2,26 @@ import BringApi from 'bring-shopping';
 
 const CATALOG_TTL_MS = 12 * 60 * 60 * 1000;
 const CATALOG_TIMEOUT_MS = 8_000;
+const SUPPORTED_CATALOG_LOCALES = ['de-DE', 'en-GB'];
+const DEFAULT_CATALOG_LOCALE = 'de-DE';
 
 const SECTION_ICONS = [
-  [/obst|gemüse|früchte/i, '🥦'],
-  [/brot|gebäck/i, '🥨'],
-  [/milch|käse/i, '🥛'],
-  [/fleisch|fisch/i, '🐟'],
-  [/zutaten|gewürze/i, '🫙'],
-  [/fertig|tiefkühl/i, '❄️'],
-  [/getreide/i, '🌾'],
-  [/snacks|süss|süß/i, '🍫'],
-  [/getränke|tabak/i, '🧃'],
-  [/haushalt/i, '🧽'],
-  [/pflege|gesundheit/i, '🧴'],
-  [/tierbedarf/i, '🐾'],
-  [/baumarkt|garten/i, '🌿']
+  [/obst|gemüse|früchte|fruit|vegetable/i, '🥦'],
+  [/brot|gebäck|bread|bakery|pastr/i, '🥨'],
+  [/milch|käse|dairy|milk|cheese|egg/i, '🥛'],
+  [/fleisch|fisch|meat|fish|seafood/i, '🐟'],
+  [/zutaten|gewürze|ingredient|spice|condiment/i, '🫙'],
+  [/fertig|tiefkühl|frozen|convenience|ready/i, '❄️'],
+  [/getreide|grain|cereal|pasta/i, '🌾'],
+  [/snacks|süss|süß|sweet|candy/i, '🍫'],
+  [/getränke|tabak|beverage|drink|tobacco/i, '🧃'],
+  [/haushalt|household|cleaning/i, '🧽'],
+  [/pflege|gesundheit|care|health|hygiene/i, '🧴'],
+  [/tierbedarf|pet/i, '🐾'],
+  [/baumarkt|garten|diy|garden|hardware/i, '🌿']
 ];
 
-const FALLBACK_SECTIONS = [
+const FALLBACK_SECTIONS_DE = [
   {
     name: 'Obst & Gemüse',
     icon: '🥦',
@@ -120,8 +122,117 @@ const FALLBACK_SECTIONS = [
   }
 ];
 
-let cachedCatalog = null;
-let pendingCatalog = null;
+const FALLBACK_SECTIONS_EN = [
+  {
+    name: 'Fruits & Vegetables',
+    icon: '🥦',
+    items: [
+      'Apples', 'Bananas', 'Pears', 'Strawberries', 'Grapes', 'Lemons',
+      'Oranges', 'Avocado', 'Tomatoes', 'Cucumbers', 'Peppers', 'Potatoes',
+      'Onions', 'Garlic', 'Carrots', 'Broccoli', 'Cauliflower',
+      'Mushrooms', 'Lettuce', 'Spinach', 'Leek', 'Chives'
+    ]
+  },
+  {
+    name: 'Bread & Pastries',
+    icon: '🥨',
+    items: [
+      'Bread', 'Bread rolls', 'Toast', 'Baguette', 'Crispbread',
+      'Croissants', 'Wraps'
+    ]
+  },
+  {
+    name: 'Milk & Cheese',
+    icon: '🥛',
+    items: [
+      'Milk', 'Oat milk', 'Butter', 'Margarine', 'Eggs', 'Yoghurt',
+      'Quark', 'Cream', 'Crème fraîche', 'Cheese', 'Cream cheese',
+      'Mozzarella', 'Feta'
+    ]
+  },
+  {
+    name: 'Meat & Fish',
+    icon: '🐟',
+    items: [
+      'Minced meat', 'Chicken', 'Sausages', 'Cold cuts', 'Ham',
+      'Salmon', 'Tuna'
+    ]
+  },
+  {
+    name: 'Ingredients & Spices',
+    icon: '🫙',
+    items: [
+      'Flour', 'Sugar', 'Salt', 'Pepper', 'Oil', 'Vinegar', 'Ketchup',
+      'Mayonnaise', 'Mustard', 'Tomato paste', 'Tinned tomatoes', 'Stock',
+      'Baking powder'
+    ]
+  },
+  {
+    name: 'Frozen & Convenience',
+    icon: '❄️',
+    items: [
+      'Frozen pizza', 'Chips', 'Frozen vegetables', 'Fish fingers',
+      'Ice cream', 'Ready meal'
+    ]
+  },
+  {
+    name: 'Grain Products',
+    icon: '🌾',
+    items: [
+      'Pasta', 'Rice', 'Oats', 'Muesli', 'Cornflakes', 'Couscous',
+      'Lentils'
+    ]
+  },
+  {
+    name: 'Snacks & Sweets',
+    icon: '🍫',
+    items: [
+      'Chocolate spread', 'Chocolate', 'Biscuits', 'Crisps', 'Nuts',
+      'Gummy bears', 'Cereal bars'
+    ]
+  },
+  {
+    name: 'Beverages',
+    icon: '🧃',
+    items: [
+      'Sparkling water', 'Juice', 'Coffee', 'Tea', 'Cocoa', 'Lemonade',
+      'Beer', 'Wine'
+    ]
+  },
+  {
+    name: 'Household',
+    icon: '🧽',
+    items: [
+      'Washing-up liquid', 'Dishwasher tabs', 'Laundry detergent',
+      'Kitchen roll', 'Toilet paper', 'Bin bags', 'Aluminium foil',
+      'Baking paper', 'All-purpose cleaner', 'Sponges'
+    ]
+  },
+  {
+    name: 'Care & Health',
+    icon: '🧴',
+    items: [
+      'Toothpaste', 'Toothbrushes', 'Shower gel', 'Shampoo', 'Soap',
+      'Deodorant', 'Tissues', 'Plasters'
+    ]
+  },
+  {
+    name: 'Pet Supplies',
+    icon: '🐾',
+    items: ['Dog food', 'Cat food', 'Cat litter', 'Treats']
+  }
+];
+
+const cachedCatalogs = new Map();
+const pendingCatalogs = new Map();
+
+function normalizeCatalogLocale(locale) {
+  const cleaned = String(locale || '').trim();
+  if (SUPPORTED_CATALOG_LOCALES.includes(cleaned)) return cleaned;
+  return cleaned.toLowerCase().startsWith('en')
+    ? 'en-GB'
+    : DEFAULT_CATALOG_LOCALE;
+}
 
 function cleanLabel(value, fallback = '') {
   return String(value || fallback).trim().slice(0, 120);
@@ -145,7 +256,15 @@ function makeSectionId(name, index) {
   return slug || `bereich-${index + 1}`;
 }
 
-export function normalizeBringCatalog(payload, source = 'bring') {
+export function normalizeBringCatalog(
+  payload,
+  source = 'bring',
+  locale = DEFAULT_CATALOG_LOCALE
+) {
+  const catalogLocale = normalizeCatalogLocale(payload?.language || locale);
+  const sectionFallbackLabel = catalogLocale.startsWith('en')
+    ? 'Section'
+    : 'Bereich';
   const sourceSections = Array.isArray(payload?.catalog?.sections)
     ? payload.catalog.sections
     : [];
@@ -154,7 +273,7 @@ export function normalizeBringCatalog(payload, source = 'bring') {
     .map((section, sectionIndex) => {
       const name = cleanLabel(
         section?.name || section?.sectionId,
-        `Bereich ${sectionIndex + 1}`
+        `${sectionFallbackLabel} ${sectionIndex + 1}`
       );
       const icon = sectionIcon(name);
       const items = (Array.isArray(section?.items) ? section.items : [])
@@ -181,7 +300,7 @@ export function normalizeBringCatalog(payload, source = 'bring') {
     .filter(section => section.items.length > 0);
 
   return {
-    locale: cleanLabel(payload?.language, 'de-DE'),
+    locale: cleanLabel(payload?.language, locale),
     source,
     sections,
     total: sections.reduce((sum, section) => sum + section.items.length, 0),
@@ -189,28 +308,33 @@ export function normalizeBringCatalog(payload, source = 'bring') {
   };
 }
 
-function fallbackCatalog() {
+function fallbackCatalog(locale = DEFAULT_CATALOG_LOCALE) {
+  const catalogLocale = normalizeCatalogLocale(locale);
+  const fallbackSections = catalogLocale === 'en-GB'
+    ? FALLBACK_SECTIONS_EN
+    : FALLBACK_SECTIONS_DE;
   return normalizeBringCatalog(
     {
-      language: 'de-DE',
+      language: catalogLocale,
       catalog: {
-        sections: FALLBACK_SECTIONS.map(section => ({
+        sections: fallbackSections.map(section => ({
           sectionId: section.name,
           name: section.name,
           items: section.items.map(name => ({ itemId: name, name }))
         }))
       }
     },
-    'fallback'
+    'fallback',
+    catalogLocale
   );
 }
 
-async function fetchLiveCatalog() {
+async function fetchLiveCatalog(locale) {
   const client = new BringApi({ mail: '', password: '' });
   let timer;
   try {
     return await Promise.race([
-      client.loadCatalog('de-DE'),
+      client.loadCatalog(locale),
       new Promise((_, reject) => {
         timer = setTimeout(
           () => reject(new Error('Bring!-Katalog Zeitüberschreitung')),
@@ -223,35 +347,37 @@ async function fetchLiveCatalog() {
   }
 }
 
-export async function loadBringCatalog() {
-  if (
-    cachedCatalog &&
-    Date.now() - cachedCatalog.updatedAt < CATALOG_TTL_MS
-  ) {
-    return cachedCatalog;
+export async function loadBringCatalog(locale = DEFAULT_CATALOG_LOCALE) {
+  const catalogLocale = normalizeCatalogLocale(locale);
+  const cached = cachedCatalogs.get(catalogLocale);
+  if (cached && Date.now() - cached.updatedAt < CATALOG_TTL_MS) {
+    return cached;
   }
-  if (pendingCatalog) return pendingCatalog;
+  if (pendingCatalogs.has(catalogLocale)) {
+    return pendingCatalogs.get(catalogLocale);
+  }
 
-  pendingCatalog = (async () => {
+  const pending = (async () => {
     try {
       const liveCatalog = normalizeBringCatalog(
-        await fetchLiveCatalog(),
-        'bring'
+        await fetchLiveCatalog(catalogLocale),
+        'bring',
+        catalogLocale
       );
       if (liveCatalog.total === 0) {
         throw new Error('Bring!-Katalog ist leer');
       }
-      cachedCatalog = liveCatalog;
+      cachedCatalogs.set(catalogLocale, liveCatalog);
     } catch (error) {
-      if (!cachedCatalog) {
-        cachedCatalog = fallbackCatalog();
+      if (!cachedCatalogs.has(catalogLocale)) {
+        cachedCatalogs.set(catalogLocale, fallbackCatalog(catalogLocale));
       }
       console.warn(`Bring!-Katalog nicht erreichbar: ${error.message}`);
     } finally {
-      pendingCatalog = null;
+      pendingCatalogs.delete(catalogLocale);
     }
-    return cachedCatalog;
+    return cachedCatalogs.get(catalogLocale);
   })();
-
-  return pendingCatalog;
+  pendingCatalogs.set(catalogLocale, pending);
+  return pending;
 }

--- a/server/locales/de.json
+++ b/server/locales/de.json
@@ -381,6 +381,8 @@
     "internalNextcloudAddress": "Interne Nextcloud-Adresse"
   },
   "labels": {
+    "htmlTitle": "LX Family Planner - Unser Familienplaner",
+    "htmlDescription": "Übersichtlicher, intuitiver Familienplaner mit Kalender, Bring!-Einkaufsliste, Essensplaner, Haushaltsaufgaben, Belohnungssystem und Pinnwand.",
     "someone": "Jemand",
     "theCreator": "dem Ersteller",
     "parent": "Elternteil",

--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -381,6 +381,8 @@
     "internalNextcloudAddress": "Internal Nextcloud address"
   },
   "labels": {
+    "htmlTitle": "LX Family Planner - Our Family Planner",
+    "htmlDescription": "Clear, intuitive family planner with calendar, Bring! shopping list, meal planner, household chores, rewards system and pinboard.",
     "someone": "Someone",
     "theCreator": "the creator",
     "parent": "Parent",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,21 @@ import { isCapacitorNative } from './utils/apiConfig';
 
 const EMPTY_DISABLED_MODULES = [];
 
+const DEEP_LINK_VIEWS = new Set([
+  'dashboard',
+  'chat',
+  'calendar',
+  'trash',
+  'tasks',
+  'board',
+  'shopping',
+  'meals',
+  'family-life',
+  'cloud',
+  'mail',
+  'admin'
+]);
+
 function MainContent() {
   const { t } = useTranslation('chrome');
   const {
@@ -60,21 +75,8 @@ function MainContent() {
     const requestedView = isRecipeShareTarget
       ? 'meals'
       : url.searchParams.get('view');
-    const allowedViews = new Set([
-      'dashboard',
-      'chat',
-      'calendar',
-      'tasks',
-      'board',
-      'shopping',
-      'meals',
-      'family-life',
-      'cloud',
-      'mail',
-      'admin'
-    ]);
     if (
-      allowedViews.has(requestedView) &&
+      DEEP_LINK_VIEWS.has(requestedView) &&
       (!readOnlyDemo || requestedView !== 'cloud') &&
       canAccessAppView(activeMember, requestedView, disabledModules)
     ) {
@@ -112,20 +114,7 @@ function MainContent() {
       try {
         const target = new URL(data.url || '/', window.location.origin);
         const requestedView = target.searchParams.get('view') || 'dashboard';
-        const allowedViews = new Set([
-          'dashboard',
-          'chat',
-          'calendar',
-          'tasks',
-          'board',
-          'shopping',
-          'meals',
-          'family-life',
-          'cloud',
-          'mail',
-          'admin'
-        ]);
-        if (!allowedViews.has(requestedView)) return;
+        if (!DEEP_LINK_VIEWS.has(requestedView)) return;
         if (readOnlyDemo && requestedView === 'cloud') return;
         if (!canAccessAppView(activeMember, requestedView, disabledModules)) {
           return;

--- a/src/components/Calendar/TrashCalendarView.jsx
+++ b/src/components/Calendar/TrashCalendarView.jsx
@@ -21,79 +21,54 @@ import EventReminderDialog from './EventReminderDialog';
 import EventReminderPicker from './EventReminderPicker';
 
 const TRASH_TYPES = [
-  {
-    id: 'rest',
-    name: 'Restmüll (Schwarze Tonne)',
-    color: '#4b5563',
-    icon: '🗑️'
-  },
-  {
-    id: 'papier',
-    name: 'Altpapier (Blaue Tonne)',
-    color: '#2563eb',
-    icon: '📦'
-  },
-  {
-    id: 'bio',
-    name: 'Biomüll (Braune/Grüne Tonne)',
-    color: '#15803d',
-    icon: '🍎'
-  },
-  {
-    id: 'gelb',
-    name: 'Gelber Sack / Wertstoff',
-    color: '#d97706',
-    icon: '🟡'
-  }
+  { id: 'rest', color: '#4b5563', icon: '🗑️' },
+  { id: 'papier', color: '#2563eb', icon: '📦' },
+  { id: 'bio', color: '#15803d', icon: '🍎' },
+  { id: 'gelb', color: '#d97706', icon: '🟡' }
 ];
 
-export const INITIAL_TRASH_EVENTS = [
-  {
-    id: 'trsh-1',
-    title: 'Restmüll (Schwarze Tonne)',
-    date: new Date(Date.now() + 86_400_000).toISOString().split('T')[0],
-    type: 'rest',
+export function initialTrashEvents(t) {
+  return TRASH_TYPES.map((type, index) => ({
+    id: `trsh-${index + 1}`,
+    title: t(`trash.types.${type.id}`),
+    date: new Date(Date.now() + 86_400_000 * (index * 2 + 1))
+      .toISOString()
+      .split('T')[0],
+    type: type.id,
     reminders: [...TRASH_DEFAULT_REMINDERS]
-  },
-  {
-    id: 'trsh-2',
-    title: 'Altpapier (Blaue Tonne)',
-    date: new Date(Date.now() + 86_400_000 * 3).toISOString().split('T')[0],
-    type: 'papier',
-    reminders: [...TRASH_DEFAULT_REMINDERS]
-  },
-  {
-    id: 'trsh-3',
-    title: 'Biomüll (Braune Tonne)',
-    date: new Date(Date.now() + 86_400_000 * 5).toISOString().split('T')[0],
-    type: 'bio',
-    reminders: [...TRASH_DEFAULT_REMINDERS]
-  },
-  {
-    id: 'trsh-4',
-    title: 'Gelber Sack',
-    date: new Date(Date.now() + 86_400_000 * 7).toISOString().split('T')[0],
-    type: 'gelb',
-    reminders: [...TRASH_DEFAULT_REMINDERS]
-  }
-];
+  }));
+}
 
 function detectTrashType(title) {
   const normalized = String(title || '').toLocaleLowerCase('de-DE');
-  if (normalized.includes('papier') || normalized.includes('blau')) {
+  if (
+    normalized.includes('papier') ||
+    normalized.includes('blau') ||
+    normalized.includes('paper') ||
+    normalized.includes('cardboard') ||
+    normalized.includes('blue')
+  ) {
     return 'papier';
   }
   if (
     normalized.includes('bio') ||
     normalized.includes('braun') ||
-    normalized.includes('grün')
+    normalized.includes('grün') ||
+    normalized.includes('organic') ||
+    normalized.includes('compost') ||
+    normalized.includes('brown') ||
+    normalized.includes('green')
   ) {
     return 'bio';
   }
   if (
     normalized.includes('gelb') ||
     normalized.includes('wertstoff') ||
-    normalized.includes('sack')
+    normalized.includes('sack') ||
+    normalized.includes('yellow') ||
+    normalized.includes('recycl') ||
+    normalized.includes('packaging') ||
+    normalized.includes('plastic')
   ) {
     return 'gelb';
   }
@@ -118,7 +93,7 @@ export default function TrashCalendarView() {
   } = useFamily();
 
   const [isAddOpen, setIsAddOpen] = useState(false);
-  const [newTitle, setNewTitle] = useState('Restmüll (Schwarze Tonne)');
+  const [newTitle, setNewTitle] = useState(() => t('trash.types.rest'));
   const [newDate, setNewDate] = useState(
     new Date().toISOString().split('T')[0]
   );
@@ -419,15 +394,12 @@ export default function TrashCalendarView() {
                   value={newType}
                   onChange={event => {
                     setNewType(event.target.value);
-                    const type = TRASH_TYPES.find(
-                      item => item.id === event.target.value
-                    );
-                    if (type) setNewTitle(type.name);
+                    setNewTitle(t(`trash.types.${event.target.value}`));
                   }}
                 >
                   {TRASH_TYPES.map(type => (
                     <option key={type.id} value={type.id}>
-                      {type.name}
+                      {t(`trash.types.${type.id}`)}
                     </option>
                   ))}
                 </select>

--- a/src/components/Dashboard/PersonalDashboard.jsx
+++ b/src/components/Dashboard/PersonalDashboard.jsx
@@ -15,7 +15,7 @@ import {
   UtensilsCrossed
 } from 'lucide-react';
 import { useFamily } from '../../context/FamilyContext';
-import { INITIAL_TRASH_EVENTS } from '../Calendar/TrashCalendarView';
+import { initialTrashEvents } from '../Calendar/TrashCalendarView';
 import ChildDashboard from './ChildDashboard';
 import PetDashboard from './PetDashboard';
 import HomeAssistantWidget from './HomeAssistantWidget';
@@ -106,6 +106,7 @@ function EmptyWidget({ icon, children }) {
 
 export default function PersonalDashboard() {
   const { t } = useTranslation('dashboard');
+  const { t: tCalendar } = useTranslation('calendar');
   const {
     activeMember,
     events,
@@ -244,7 +245,7 @@ export default function PersonalDashboard() {
   const trashEvents = householdTrashEvents.length
     ? householdTrashEvents
     : activeHousehold === 'familie'
-      ? INITIAL_TRASH_EVENTS
+      ? initialTrashEvents(tCalendar)
       : [];
   const nextTrash = trashEvents
     .filter(item => item.date >= todayKey)

--- a/src/components/Meals/RecipeBook.jsx
+++ b/src/components/Meals/RecipeBook.jsx
@@ -140,8 +140,12 @@ export default function RecipeBook() {
       prepTime: manualPrepTime,
       servings: manualServings,
       image: manualImage || 'https://images.unsplash.com/photo-1498837167922-ddd27525d352?auto=format&fit=crop&w=600&q=80',
-      ingredients: ['1x Zutat 1', '2x Zutat 2'],
-      instructions: ['Zubereitungsschritt 1', 'Zubereitungsschritt 2']
+      ingredients: [1, 2].map(number =>
+        t('recipeBook.manual.placeholderIngredient', { number })
+      ),
+      instructions: [1, 2].map(number =>
+        t('recipeBook.manual.placeholderStep', { number })
+      )
     });
 
     setManualTitle('');

--- a/src/components/Shopping/BringShoppingList.jsx
+++ b/src/components/Shopping/BringShoppingList.jsx
@@ -21,44 +21,55 @@ import { useFamily } from '../../context/FamilyContext';
 import BringAccountModal from './BringAccountModal';
 
 const POPULAR_NAMES = [
-  'Eier',
-  'Milch',
-  'Butter',
-  'Käse',
-  'Joghurt',
-  'Brötchen',
-  'Brot',
-  'Bananen',
-  'Äpfel',
-  'Tomaten',
-  'Gurken',
-  'Kartoffeln',
-  'Lauch',
-  'Nudeln',
-  'Reis',
-  'Mineralwasser',
-  'Kaffee',
-  'Nougatcreme',
-  'Toilettenpapier',
-  'Spülmittel'
+  ['Eier', 'Eggs'],
+  ['Milch', 'Milk'],
+  ['Butter', 'Butter'],
+  ['Käse', 'Cheese'],
+  ['Joghurt', 'Yoghurt'],
+  ['Brötchen', 'Bread roll'],
+  ['Brot', 'Bread'],
+  ['Bananen', 'Bananas'],
+  ['Äpfel', 'Apples'],
+  ['Tomaten', 'Tomatoes'],
+  ['Gurken', 'Cucumber'],
+  ['Kartoffeln', 'Potatoes'],
+  ['Lauch', 'Leek'],
+  ['Nudeln', 'Pasta'],
+  ['Reis', 'Rice'],
+  ['Mineralwasser', 'Water'],
+  ['Kaffee', 'Coffee'],
+  ['Nougatcreme', 'Nougat cream'],
+  ['Toilettenpapier', 'Toilet paper'],
+  ['Spülmittel', 'Washing-up liquid']
 ];
 
-const PERSONAL_FAVORITES = [
-  {
-    id: 'custom-nutella',
-    name: 'Nutella',
-    category: 'Snacks & Süsswaren',
-    icon: '🍫',
-    aliases: 'nougatcreme nuss nougat aufstrich'
-  },
-  {
-    id: 'custom-porree',
-    name: 'Porree',
-    category: 'Obst & Gemüse',
-    icon: '🥦',
-    aliases: 'lauch poree'
-  }
-];
+const PERSONAL_FAVORITES = {
+  de: [
+    {
+      id: 'custom-nutella',
+      name: 'Nutella',
+      category: 'Snacks & Süsswaren',
+      icon: '🍫',
+      aliases: 'nougatcreme nuss nougat aufstrich'
+    },
+    {
+      id: 'custom-porree',
+      name: 'Porree',
+      category: 'Obst & Gemüse',
+      icon: '🥦',
+      aliases: 'lauch poree'
+    }
+  ],
+  en: [
+    {
+      id: 'custom-nutella',
+      name: 'Nutella',
+      category: 'Snacks & Sweets',
+      icon: '🍫',
+      aliases: 'nougat cream chocolate spread'
+    }
+  ]
+};
 
 const NAME_ALIASES = {
   lauch: 'porree poree',
@@ -99,7 +110,10 @@ function rankMatch(item, query) {
 }
 
 export default function BringShoppingList() {
-  const { t } = useTranslation('shopping');
+  const { t, i18n } = useTranslation('shopping');
+  const personalFavorites = i18n.language?.startsWith('en')
+    ? PERSONAL_FAVORITES.en
+    : PERSONAL_FAVORITES.de;
   const {
     shoppingItems,
     toggleShoppingSelected,
@@ -141,21 +155,21 @@ export default function BringShoppingList() {
       shoppingItems.map(item => ({
         id: `remembered-${item.id}`,
         name: item.name,
-        category: item.category || 'Eigene Artikel',
+        category: item.category || t('catalog.customCategory'),
         icon: item.icon || '🛒',
         aliases: ''
       })),
-    [shoppingItems]
+    [shoppingItems, t]
   );
 
   const allChoices = useMemo(
     () =>
       uniqueByName([
-        ...PERSONAL_FAVORITES,
+        ...personalFavorites,
         ...catalogItems,
         ...rememberedItems
       ]),
-    [catalogItems, rememberedItems]
+    [catalogItems, personalFavorites, rememberedItems]
   );
 
   const popularItems = useMemo(() => {
@@ -163,10 +177,14 @@ export default function BringShoppingList() {
       allChoices.map(item => [normalizeSearch(item.name), item])
     );
     return uniqueByName([
-      ...POPULAR_NAMES.map(name => byName.get(normalizeSearch(name))).filter(Boolean),
-      ...PERSONAL_FAVORITES
+      ...POPULAR_NAMES
+        .map(names =>
+          names.map(name => byName.get(normalizeSearch(name))).find(Boolean)
+        )
+        .filter(Boolean),
+      ...personalFavorites
     ]);
-  }, [allChoices]);
+  }, [allChoices, personalFavorites]);
 
   const visibleCatalog = useMemo(() => {
     const normalizedQuery = normalizeSearch(query);

--- a/src/i18n/locales/de/calendar.json
+++ b/src/i18n/locales/de/calendar.json
@@ -116,6 +116,12 @@
       "dateLabel": "Abholdatum",
       "save": "Termin speichern"
     },
+    "types": {
+      "rest": "Restmüll (Schwarze Tonne)",
+      "papier": "Altpapier (Blaue Tonne)",
+      "bio": "Biomüll (Braune/Grüne Tonne)",
+      "gelb": "Gelber Sack / Wertstoff"
+    },
     "toast": {
       "importFailedTitle": "Import nicht möglich",
       "importFailedBody": "In dieser Datei wurden keine Mülltermine gefunden.",

--- a/src/i18n/locales/de/meals.json
+++ b/src/i18n/locales/de/meals.json
@@ -90,7 +90,9 @@
       "dishTitlePlaceholder": "z. B. Papas berühmte Bolognese",
       "prepTimeLabel": "Zubereitungszeit",
       "servingsLabel": "Portionen",
-      "submit": "Rezept Speichern"
+      "submit": "Rezept Speichern",
+      "placeholderIngredient": "{{number}}x Zutat {{number}}",
+      "placeholderStep": "Zubereitungsschritt {{number}}"
     }
   },
   "cookingMode": {

--- a/src/i18n/locales/de/shopping.json
+++ b/src/i18n/locales/de/shopping.json
@@ -31,6 +31,7 @@
     "sourceDefault": "Grundsortiment",
     "resultsFor": "Treffer für „{{query}}“",
     "quickAdd": "Schnell hinzufügen",
+    "customCategory": "Eigene Artikel",
     "shownCount": "{{count}} angezeigt",
     "departmentsAria": "Warengruppen",
     "popular": "Häufig",

--- a/src/i18n/locales/en/calendar.json
+++ b/src/i18n/locales/en/calendar.json
@@ -116,6 +116,12 @@
       "dateLabel": "Pickup date",
       "save": "Save pickup"
     },
+    "types": {
+      "rest": "General waste (black bin)",
+      "papier": "Paper (blue bin)",
+      "bio": "Organic waste (brown/green bin)",
+      "gelb": "Yellow bag / recyclables"
+    },
     "toast": {
       "importFailedTitle": "Import not possible",
       "importFailedBody": "No waste collection dates were found in this file.",

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -155,7 +155,7 @@
         "action": "Meal plan"
       },
       "shopping": {
-        "label": "Still to buy",
+        "label": "Shopping list",
         "description": "The most important open items at a glance",
         "action": "Shopping list"
       },

--- a/src/i18n/locales/en/familyLife.json
+++ b/src/i18n/locales/en/familyLife.json
@@ -119,7 +119,7 @@
       "enabled": "Timetable on",
       "disabled": "Timetable off",
       "disabledTitle": "The school area is turned off for this child",
-      "disabledHint": "Enable it only for schoolchildren. Parents can then edit it and the child can view their own timetable.",
+      "disabledHint": "Enable it only for school children. Parents can then edit it and the child can view their own timetable.",
       "enable": "Enable school area"
     },
     "timetable": {

--- a/src/i18n/locales/en/familyLife.json
+++ b/src/i18n/locales/en/familyLife.json
@@ -119,7 +119,7 @@
       "enabled": "Timetable on",
       "disabled": "Timetable off",
       "disabledTitle": "The school area is turned off for this child",
-      "disabledHint": "Enable it only for school children. Parents can then edit it and the child can view their own timetable.",
+      "disabledHint": "Enable it only for schoolchildren. Parents can then edit it and the child can view their own timetable.",
       "enable": "Enable school area"
     },
     "timetable": {

--- a/src/i18n/locales/en/meals.json
+++ b/src/i18n/locales/en/meals.json
@@ -90,7 +90,9 @@
       "dishTitlePlaceholder": "e.g. Dad's famous Bolognese",
       "prepTimeLabel": "Preparation time",
       "servingsLabel": "Servings",
-      "submit": "Save Recipe"
+      "submit": "Save Recipe",
+      "placeholderIngredient": "{{number}}x ingredient {{number}}",
+      "placeholderStep": "Preparation step {{number}}"
     }
   },
   "cookingMode": {

--- a/src/i18n/locales/en/shopping.json
+++ b/src/i18n/locales/en/shopping.json
@@ -12,7 +12,7 @@
     "connectBring": "Connect Bring!"
   },
   "search": {
-    "placeholder": "Eier, Nutella, Brötchen, Porree …",
+    "placeholder": "Eggs, Nutella, bread rolls, leek …",
     "searchAria": "Search for an item or create a new one",
     "quantityLabel": "Quantity",
     "quantityAria": "Quantity or note",
@@ -20,7 +20,7 @@
   },
   "list": {
     "kicker": "Your list",
-    "title": "Still to buy",
+    "title": "Shopping list",
     "emptyTitle": "The shopping basket is waiting.",
     "emptyHint": "Tap a standard item below or search for it directly.",
     "recentToggle": "Recently bought ({{count}})",

--- a/src/i18n/locales/en/shopping.json
+++ b/src/i18n/locales/en/shopping.json
@@ -2,7 +2,7 @@
   "hero": {
     "eyebrow": "Family market",
     "title": "What's missing at home?",
-    "subtitle": "Browse the full German Bring! catalog or add an item of your own.",
+    "subtitle": "Browse the full Bring! catalog or add an item of your own.",
     "statusLive": "Live with “{{listName}}”",
     "statusLocal": "Local family list",
     "catalogItems": "{{total}} standard items",
@@ -31,6 +31,7 @@
     "sourceDefault": "Basic range",
     "resultsFor": "Results for “{{query}}”",
     "quickAdd": "Quick add",
+    "customCategory": "Own items",
     "shownCount": "{{count}} shown",
     "departmentsAria": "Product categories",
     "popular": "Popular",


### PR DESCRIPTION
… Catalog and fallback catalogs, the trash calendar dropdown items, the example recipe items, and a few translation wordings. Additionally, while translating the trash dropdown I noticed the trash deeplinking wasn't working from the notifications panel and corrected the list of available deeplinks.

## Was ändert sich?

Some remaining items were left un-translated. Now that I've got more context and was able to see what was remaining, I updated those remaining items and some strange wordings. First I used the Bring! catalog api locale and swapped the fallback catalogs to include the list of items from their catalog and headings. This should allow the Bring! Connect functionality to continue to work with the APP_LANGUAGE set to en while having the catalog be in English. 

Additionally, the list of items in the Trash calendar dropdown were not translated previously. Although these categories don't make a whole lot of sense in other countries, the dropdown should be at least usable until there is a management mechanism to swap out what the trash calendar categories should be in your country.  While working on this I noticed the deeplinks in the notification panel didn't work because "trash" wasn't an allowed deeplink name. I added that to the list.

Next, I updated the example recipe that is created when a new recipe is added to have an English substitute. 

Lastly, a few translations were a little clunky and I updated them. I'll continue to keep an eye on these.

## Warum ist das für Familien hilfreich?

Hopefully this should make the application more fully usable in English.

## Geprüft

- [X] `npm run check` ist erfolgreich.
- [X] Desktop-Ansicht geprüft.
- [X] Mobile Ansicht geprüft.
- [X] Rollen und Berechtigungen geprüft.
- [X] Bestehende Daten und Einstellungen bleiben erhalten.
- [X] Keine Zugangsdaten oder privaten Familiendaten eingecheckt.

## Bilder

<img width="725" height="742" alt="Screenshot 2026-08-03 at 12 41 04 PM" src="https://github.com/user-attachments/assets/9a567b76-2dd4-4a56-a79d-6a2d0c526ec7" />
<img width="1440" height="1000" alt="bring-catalog" src="https://github.com/user-attachments/assets/479c5a36-d9ff-4ec6-b3d9-1cc0688eaafb" />
<img width="1440" height="1000" alt="recipe-new" src="https://github.com/user-attachments/assets/96a5e6be-4c3d-41b5-bb44-919458d6c87d" />



