### PR TITLE
Add a quickrun.yml so the repository starts with one click

### DIFF
--- a/quickrun.yml
+++ b/quickrun.yml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://fgilde.github.io/QuickRun/quickrun.schema.json
+#
+# Runs LX Family locally without Docker, the way "Without Docker" in the README does:
+# install, build, start. Everything stays inside this checkout - the SQLite database and
+# the backups land in data/ and backups/ next to these files.
+#
+# For a real household installation follow docs/INSTALL.md: this starts the server with
+# the development APP_SECRET, which is fine for looking around and not for family data.
+version: 1
+name: LX Family
+description: >-
+  A self-hosted Family OS with separate spaces for parents, children, grandparents and pets.
+  Starts on http://localhost:3001, where the first family can be created.
+docs: https://github.com/laxxx-lab/lx-family-planner/blob/main/docs/INSTALL.md
+
+requires:
+  - tool: node
+    version: ">=22.13"
+    install: https://nodejs.org/en/download
+
+inputs:
+  - id: port
+    label: Port
+    type: number
+    description: Where LX Family listens. 3001 unless something else already has it.
+    default: "3001"
+    min: 1024
+    max: 65535
+    env: PORT
+  - id: language
+    label: Language
+    type: select
+    description: The interface language of a new installation.
+    options: [de, en, fr, es, it, nl, pl]
+    default: de
+    env: APP_LANGUAGE
+
+setup:
+  - npm ci
+  - npm run build
+
+tasks:
+  - name: lx-family
+    run: npm start
+    readyWhen: {http: "http://localhost:${inputs.port}"}
+    open: true


### PR DESCRIPTION
This adds a single file, `quickrun.yml`, describing the **Without Docker** path from the README as machine-readable steps. Nothing else changes, and the Docker setup is untouched.

### What it describes

```yaml
requires:  node >=22.13
setup:     npm ci, npm run build
tasks:     npm start, ready when http://localhost:${inputs.port} answers
inputs:    port (default 3001), language (de/en/fr/es/it/nl/pl)
```

Port and language become a small form before the run and are passed as `PORT` and `APP_LANGUAGE`, which is what `server/app.js` already reads.

### What it is for

[QuickRun](https://github.com/fgilde/QuickRun) is an open-source launcher (Windows, macOS, Linux, MIT). With a config like this in the repository, someone can go from "found this project" to a running LX Family without reading the setup documentation first: it checks the repository out into its own workspace, installs Node if the machine does not have a new enough one, runs the steps and opens the app when it answers. Every command is shown for confirmation before anything executes.

The file is inert for everyone else - it is not read by npm, Docker or CI.

### Tested

Run end to end on Windows against `main` (1.20.0): `npm ci`, `vite build`, `npm start`, first response on `http://localhost:3001` (HTTP 200, the profile selection). Also with `port=3005` and `language=en`, where the server came up on 3005 and the page rendered as `<html lang="en">`.

### Two notes

- It starts the server without a `.env`, so the development `APP_SECRET` from `server/app.js` applies - fine for looking around, and the comment at the top of the file says so and points at `docs/INSTALL.md` for a real household installation.
- SQLite data and backups land in `data/` and `backups/` inside the checkout QuickRun manages, so nothing is written outside it.

Happy to adjust anything - naming, defaults, the wording of the description - or to close this if a config in the repository is not something you want.
