### PR TITLE
docs: add a QuickRun badge to the READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -14,6 +14,7 @@
 </p>
 
 <p align="center">
+  <a href="https://quickrun.org/run?repo=laxxx-lab%2Flx-family-planner"><img alt="Dieses Repository mit QuickRun starten" src="https://quickrun.org/badge.svg"></a>
   <a href="https://github.com/laxxx-lab/lx-family-planner/actions/workflows/ci.yml"><img alt="Qualitätsprüfung" src="https://github.com/laxxx-lab/lx-family-planner/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Aktuelles Release 1.20.0" src="https://img.shields.io/badge/Release-1.20.0-17483F">
   <img alt="Node.js 22+" src="https://img.shields.io/badge/Node.js-22%2B-43853D?logo=nodedotjs&logoColor=white">

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 </p>
 
 <p align="center">
+  <a href="https://quickrun.org/run?repo=laxxx-lab%2Flx-family-planner"><img alt="Run this repository with QuickRun" src="https://quickrun.org/badge.svg"></a>
   <a href="https://github.com/laxxx-lab/lx-family-planner/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/laxxx-lab/lx-family-planner/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="Latest release 1.20.0" src="https://img.shields.io/badge/release-1.20.0-17483F">
   <img alt="Node.js 22+" src="https://img.shields.io/badge/Node.js-22%2B-43853D?logo=nodedotjs&logoColor=white">


### PR DESCRIPTION
## What this adds

One badge in each README, pointing at the QuickRun page for this repository:

[![QuickRun](https://quickrun.org/badge.svg)](https://quickrun.org/run?repo=laxxx-lab%2Flx-family-planner)

It sits in the block with the CI, release and platform badges, written as HTML so it matches the
badges already there.

## What it does for someone who clicks it

The link lands on a page that looks for QuickRun on the visitor's own machine. With QuickRun
installed, the planner is checked out and its `quickrun.yml` - the one already in this repository -
is turned into a plan. **Nothing runs until the visitor has read the exact commands and confirmed
them**; the page itself cannot execute anything. Without QuickRun installed, the same link explains
what it is and offers the download, so the badge is never a dead end.

## What it does not do

- No workflow, no dependency, no configuration change - two README lines, nothing else.
- Nothing is sent anywhere: the page talks to `127.0.0.1` on the visitor's machine, or to nothing.
- The badge image is a static SVG.

QuickRun is open source (MIT): https://github.com/fgilde/QuickRun · https://quickrun.org

Happy to change the wording, the placement, or to drop the German one if you would rather keep the
change to a single file.
